### PR TITLE
Fix/8 Fixed CORS Problem

### DIFF
--- a/src/main/java/kr/pe/aichief/config/WebConfig.java
+++ b/src/main/java/kr/pe/aichief/config/WebConfig.java
@@ -1,0 +1,20 @@
+package kr.pe.aichief.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins(
+					"https://main.ddnum7vb34gxw.amplifyapp.com",
+					"https://dev.ddnum7vb34gxw.amplifyapp.com"
+			);
+	}
+}

--- a/src/main/java/kr/pe/aichief/config/WebConfig.java
+++ b/src/main/java/kr/pe/aichief/config/WebConfig.java
@@ -12,9 +12,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins(
-					"https://main.ddnum7vb34gxw.amplifyapp.com",
-					"https://dev.ddnum7vb34gxw.amplifyapp.com"
-			);
+			.allowedOrigins("https://dev.ddnum7vb34gxw.amplifyapp.com")
+			.allowCredentials(true);
 	}
 }

--- a/src/main/java/kr/pe/aichief/controller/ActorController.java
+++ b/src/main/java/kr/pe/aichief/controller/ActorController.java
@@ -2,7 +2,6 @@ package kr.pe.aichief.controller;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,7 +13,6 @@ import kr.pe.aichief.model.service.ActorService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@CrossOrigin(origins = "https://main.ddnum7vb34gxw.amplifyapp.com")
 @RequestMapping("/search")
 @RequiredArgsConstructor
 public class ActorController {

--- a/src/main/java/kr/pe/aichief/controller/ActorController.java
+++ b/src/main/java/kr/pe/aichief/controller/ActorController.java
@@ -2,6 +2,7 @@ package kr.pe.aichief.controller;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,6 +14,7 @@ import kr.pe.aichief.model.service.ActorService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@CrossOrigin(origins = "https://main.ddnum7vb34gxw.amplifyapp.com")
 @RequestMapping("/search")
 @RequiredArgsConstructor
 public class ActorController {


### PR DESCRIPTION
# 💡 해결 방법
* WebMvcConfigurer interface를 구현하는 WebConfig class를 생성함.
* addCorsMappings method를 override.
* React app의 모든 요청에 대해 허용하도록 출처를 명시함.
* allowCredentials를 true로 설정함.