### PR TITLE
Update health check for application load balancer target group

### DIFF
--- a/src/main/java/kr/pe/aichief/controller/HealthController.java
+++ b/src/main/java/kr/pe/aichief/controller/HealthController.java
@@ -1,16 +1,17 @@
 package kr.pe.aichief.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/test")
-public class TestController {
+@RequestMapping("/")
+public class HealthController {
 	
 	@GetMapping
-	public String hello(@RequestParam("name") String name) {
-		return String.join(" ", name, "Test Success");
+	public ResponseEntity<HttpStatus> healthCheck() {
+		return new ResponseEntity<HttpStatus>(HttpStatus.OK);
 	}
 }


### PR DESCRIPTION
# 💡 해결 방법
* AWS Route 53 서비스로 도메인 구매 및 등록
* AWS Certificate Manager 서비스로 SSL/TLS 인증서 발급
* Application Load Balancer를 위한 target group 생성. Target group 생성 시 포트 번호는 서비스가 사용 중인 5000번으로 수정.
* Application Load Balancer 생성
* 등록된 도메인에 레코드 생성해 도메인과 Application Load Balancer 연결