### PR TITLE
청구 접수 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/kr/pe/aichief/controller/ClaimController.java
+++ b/src/main/java/kr/pe/aichief/controller/ClaimController.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
 import kr.pe.aichief.model.dto.ClaimRequest;
 import kr.pe.aichief.model.dto.MyResponse;
 import kr.pe.aichief.model.service.ClaimService;
@@ -28,11 +31,11 @@ public class ClaimController {
 	private final ClaimService claimService;
 	
 	@PostMapping
-	public ResponseEntity<MyResponse> postClaim(@RequestBody ClaimRequest claimRequset) {
+	public ResponseEntity<MyResponse> receiveClaim(@RequestBody ClaimRequest claimRequset) throws JsonMappingException, JsonProcessingException {
 		
 		MyResponse result = MyResponse.builder().contents(new ArrayList<Object>()).build();
 		
-		result.getContents().add(claimService.claim(claimRequset));
+		result.getContents().add(claimService.serveClaim(claimRequset));
 		
 		result.setCode(HttpStatus.OK.value());
 		result.setHttpStatus(HttpStatus.OK);

--- a/src/main/java/kr/pe/aichief/controller/InfoController.java
+++ b/src/main/java/kr/pe/aichief/controller/InfoController.java
@@ -1,6 +1,7 @@
 package kr.pe.aichief.controller;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,21 @@ public class InfoController {
 		
 		result.setCode(HttpStatus.OK.value());
 		result.setHttpStatus(HttpStatus.OK);
-		result.setCount(1);
+		result.setCount(result.getContents().size());
+		result.setMessage("Request get info success");
+		
+		return ResponseEntity.status(result.getHttpStatus()).body(result);
+	}
+	
+	@GetMapping("/with_name")
+	public ResponseEntity<MyResponse> getInfoWithName(@RequestParam("name") String name) {
+		
+		MyResponse result = MyResponse.builder().contents(new ArrayList<Object>()).build();
+		
+		result.setContents(myPageService.getBeneficiaryWithName(name).stream().map(beneficiary -> (Object) beneficiary).collect(Collectors.toList()));
+		result.setCode(HttpStatus.OK.value());
+		result.setHttpStatus(HttpStatus.OK);
+		result.setCount(result.getContents().size());
 		result.setMessage("Request get info success");
 		
 		return ResponseEntity.status(result.getHttpStatus()).body(result);

--- a/src/main/java/kr/pe/aichief/exceptions/MyExceptionHandler.java
+++ b/src/main/java/kr/pe/aichief/exceptions/MyExceptionHandler.java
@@ -9,6 +9,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
 import kr.pe.aichief.model.dto.MyResponse;
 
 @RestControllerAdvice
@@ -25,6 +28,20 @@ public class MyExceptionHandler {
 				.contents(new ArrayList<Object>())
 				.build();
 		
-		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(result);
+		return ResponseEntity.status(result.getHttpStatus()).body(result);
+	}
+	
+	@ExceptionHandler({JsonMappingException.class, JsonProcessingException.class})
+	public ResponseEntity<MyResponse> jsonParseExceptionHadler(Exception e) {
+		
+		MyResponse result = MyResponse.builder()
+				.code(HttpStatus.SERVICE_UNAVAILABLE.value())
+				.httpStatus(HttpStatus.SERVICE_UNAVAILABLE)
+				.count(0)
+				.message(e.getMessage())
+				.contents(new ArrayList<Object>())
+				.build();
+		
+		return ResponseEntity.status(result.getHttpStatus()).body(result);
 	}
 }

--- a/src/main/java/kr/pe/aichief/model/dto/AccidentDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/AccidentDto.java
@@ -14,13 +14,15 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class AccidentDto {
+
+	private String accidentId;
 	
-	private String user;
+	private String dateTime;
 	
-	private int contract_id;
+	private String location;
 	
-	private String company;
+	private String details;
 	
-	private String image_path;
+	private String diseaseName;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/AccountDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/AccountDto.java
@@ -14,13 +14,13 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class AccountDto {
+
+	private String accountId;
 	
-	private String user;
+	private String bankName;
 	
-	private int contract_id;
+	private String number;
 	
-	private String company;
-	
-	private String image_path;
+	private String holder;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/AnotherSubscribeDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/AnotherSubscribeDto.java
@@ -14,13 +14,11 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class AnotherSubscribeDto {
 	
-	private String user;
+	private String anotherSubscribeId;
 	
-	private int contract_id;
+	private String companyName;
 	
-	private String company;
-	
-	private String image_path;
+	private String number;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/AssignDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/AssignDto.java
@@ -14,13 +14,7 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
-	
-	private String user;
-	
-	private int contract_id;
-	
-	private String company;
-	
-	private String image_path;
+public class AssignDto {
+
+	private String assignId;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ClaimDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ClaimDto.java
@@ -1,7 +1,5 @@
 package kr.pe.aichief.model.dto;
 
-import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,13 +16,9 @@ import lombok.ToString;
 
 public class ClaimDto {
 
-	private Map<String, String> claim;
+	private String claimId;
 	
-	private Map<String, String> insured;
+	private String reasonForPartialClaim;
 	
-	private Map<String, String> beneficiary;
-	
-	private Map<String, String> insurance;
-	
-	private Map<String, String> accident;
+	private String date;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ClaimResponse.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ClaimResponse.java
@@ -14,13 +14,15 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class ClaimResponse {
+
+	private String id;
 	
 	private String user;
 	
-	private int contract_id;
+	private int contractId;
 	
-	private String company;
+	private String imagePath;
 	
-	private String image_path;
+	private String result;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ClaimResult.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ClaimResult.java
@@ -14,13 +14,19 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class ClaimResult {
+
+	private ClaimDto claim;
 	
-	private String user;
+	private InsuredDto insured;
 	
-	private int contract_id;
+	private BeneficiaryDto beneficiary;
 	
-	private String company;
+	private IdentificationDto identification;
 	
-	private String image_path;
+	private AnotherSubscribeDto anotherSubscribe;
+	
+	private AccountDto account;
+	
+	private AccidentDto accident;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ContractDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ContractDto.java
@@ -1,7 +1,5 @@
 package kr.pe.aichief.model.dto;
 
-import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,11 +16,9 @@ import lombok.ToString;
 
 public class ContractDto {
 
-	private Map<String, String> contract;
+	private String contractId;
 	
-	private Map<String, String> insured;
+	private String monthlyPremium;
 	
-	private Map<String, String> beneficiary;
-	
-	private Map<String, String> insurance;
+	private String state;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/IdentificationDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/IdentificationDto.java
@@ -1,8 +1,8 @@
 package kr.pe.aichief.model.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,13 +14,15 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class IdentificationDto {
+
+	private String identificationId;
 	
-	private String user;
+	private String number;
 	
-	private int contract_id;
+	private String serialNumber;
 	
-	private String company;
+	private String issueDate;
 	
-	private String image_path;
+	private String issueBy;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/InsuranceDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/InsuranceDto.java
@@ -14,13 +14,11 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class ClaimRequest {
+public class InsuranceDto {
+
+	private String insuranceId;
 	
-	private String user;
+	private String companyName;
 	
-	private int contract_id;
-	
-	private String company;
-	
-	private String image_path;
+	private String details;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/InsuredDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/InsuredDto.java
@@ -14,9 +14,9 @@ import lombok.ToString;
 @Setter
 @ToString
 
-public class BeneficiaryDto {
+public class InsuredDto {
 
-	private String beneficiaryId;
+	private String insuredId;
 	
 	private String name;
 	
@@ -29,11 +29,4 @@ public class BeneficiaryDto {
 	private String socialSecurityNumber;
 	
 	private String job;
-	
-	private String landline;
-	
-	private String address;
-	
-	private String relationshipWithInsured;
-	
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ManagerDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ManagerDto.java
@@ -1,7 +1,5 @@
 package kr.pe.aichief.model.dto;
 
-import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,5 +16,13 @@ import lombok.ToString;
 
 public class ManagerDto {
 	
-	private Map<String, String> manager;
+	private String managerId;
+	
+	private String name;
+	
+	private String email;
+	
+	private String phoneNumber;
+	
+	private String joinDate;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/MyResponse.java
+++ b/src/main/java/kr/pe/aichief/model/dto/MyResponse.java
@@ -29,4 +29,5 @@ public class MyResponse {
 	private Integer count;
 	
 	private List<Object> contents;
+	
 }

--- a/src/main/java/kr/pe/aichief/model/dto/RecognitionResult.java
+++ b/src/main/java/kr/pe/aichief/model/dto/RecognitionResult.java
@@ -1,0 +1,64 @@
+package kr.pe.aichief.model.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@ToString
+
+public class RecognitionResult {
+
+	private List<String> insuredName;
+	
+	private List<String> insuredSocialSecurityNumber;
+	
+	private List<String> insuredPhoneNumber;
+	
+	private List<String> insuredJob;
+	
+	private List<String> beneficiaryName;
+	
+	private List<String> beneficiarySocialSecurityNumber;
+	
+	private List<String> beneficiaryPhoneNumber;
+	
+	private List<String> beneficiaryEmail;
+	
+	private List<String> beneficiaryAddress;
+	
+	private List<String> identificationNumber;
+	
+	private List<String> identificationSerialNumber;
+	
+	private List<String> identificationIssueDate;
+	
+	private List<String> identificationIssueBy;
+	
+	private List<String> accidentDateTime;
+	
+	private List<String> accidentLocation;
+	
+	private List<String> accidentDetails;
+	
+	private List<String> accidentDiseaseName;
+	
+	private List<String> anotherSubscribeCompanyName;
+	
+	private List<String> anotherSubscribeNumber;
+	
+	private List<String> accountBankName;
+	
+	private List<String> accountNumber;
+	
+	private List<String> accountHolder;
+}

--- a/src/main/java/kr/pe/aichief/model/entity/Accident.java
+++ b/src/main/java/kr/pe/aichief/model/entity/Accident.java
@@ -14,12 +14,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 @ToString
 
 @Entity

--- a/src/main/java/kr/pe/aichief/model/entity/Assign.java
+++ b/src/main/java/kr/pe/aichief/model/entity/Assign.java
@@ -2,6 +2,7 @@ package kr.pe.aichief.model.entity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -13,12 +14,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 @ToString
 
 @Entity
@@ -34,7 +37,7 @@ public class Assign {
 	private Claim claim;
 	
 	@ToString.Exclude
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "manager_id")
 	private Manager manager;
 }

--- a/src/main/java/kr/pe/aichief/model/entity/Beneficiary.java
+++ b/src/main/java/kr/pe/aichief/model/entity/Beneficiary.java
@@ -10,6 +10,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
@@ -28,6 +30,7 @@ import lombok.ToString;
 @ToString
 
 @Entity
+@NamedEntityGraph(name = "Beneficiary.anotherSubscribes", attributeNodes = @NamedAttributeNode("anotherSubscribes"))
 public class Beneficiary {
 	
 	@Id

--- a/src/main/java/kr/pe/aichief/model/entity/Claim.java
+++ b/src/main/java/kr/pe/aichief/model/entity/Claim.java
@@ -15,12 +15,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 @ToString
 
 @Entity

--- a/src/main/java/kr/pe/aichief/model/entity/Manager.java
+++ b/src/main/java/kr/pe/aichief/model/entity/Manager.java
@@ -9,6 +9,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
@@ -27,6 +29,7 @@ import lombok.ToString;
 @ToString
 
 @Entity
+@NamedEntityGraph(name = "Manager.assigns", attributeNodes = @NamedAttributeNode("assigns"))
 public class Manager {
 	
 	@Id

--- a/src/main/java/kr/pe/aichief/model/repository/AccidentRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/AccidentRepository.java
@@ -1,0 +1,15 @@
+package kr.pe.aichief.model.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pe.aichief.model.entity.Accident;
+
+public interface AccidentRepository extends JpaRepository<Accident, Integer> {
+
+	List<Accident> findAllByOrderByAccidentIdDesc();
+	
+	Optional<Accident> findByClaim_Contract_ContractId(int id);
+}

--- a/src/main/java/kr/pe/aichief/model/repository/AccountRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/AccountRepository.java
@@ -1,0 +1,15 @@
+package kr.pe.aichief.model.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pe.aichief.model.entity.Account;
+
+public interface AccountRepository extends JpaRepository<Account, Integer> {
+
+	Optional<Account> findByBeneficiary_BeneficiaryId(int id);
+	
+	List<Account> findAllByOrderByAccountIdDesc();
+}

--- a/src/main/java/kr/pe/aichief/model/repository/AnotherSubscribeRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/AnotherSubscribeRepository.java
@@ -1,0 +1,15 @@
+package kr.pe.aichief.model.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pe.aichief.model.entity.AnotherSubscribe;
+
+public interface AnotherSubscribeRepository extends JpaRepository<AnotherSubscribe, Integer> {
+
+	Optional<AnotherSubscribe> findByBeneficiary_BeneficiaryId(int id);
+	
+	List<AnotherSubscribe> findAllByOrderByAnotherSubscribeIdDesc();
+}

--- a/src/main/java/kr/pe/aichief/model/repository/AssignRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/AssignRepository.java
@@ -9,4 +9,6 @@ import kr.pe.aichief.model.entity.Assign;
 public interface AssignRepository extends JpaRepository<Assign, Integer> {
 
 	List<Assign> findByManager_Email(String email);
+	
+	List<Assign> findAllByOrderByAssignIdDesc();
 }

--- a/src/main/java/kr/pe/aichief/model/repository/BeneficiaryRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/BeneficiaryRepository.java
@@ -1,7 +1,9 @@
 package kr.pe.aichief.model.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.pe.aichief.model.entity.Beneficiary;
@@ -9,4 +11,9 @@ import kr.pe.aichief.model.entity.Beneficiary;
 public interface BeneficiaryRepository extends JpaRepository<Beneficiary, Integer> {
 
 	Optional<Beneficiary> findByEmail(String email);
+	
+	List<Beneficiary> findByName(String name);
+	
+	@EntityGraph(value = "Beneficiary.anotherSubscribes")
+	Optional<Beneficiary> findByBeneficiaryId(int id);
 }

--- a/src/main/java/kr/pe/aichief/model/repository/ClaimRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/ClaimRepository.java
@@ -1,6 +1,7 @@
 package kr.pe.aichief.model.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,8 @@ public interface ClaimRepository extends JpaRepository<Claim, Integer> {
 	List<Claim> findByContract_Beneficiary_Email(String email);
 	
 	List<Claim> findByAssign_Manager_Email(String email);
+	
+	Optional<Claim> findByContract_ContractId(int contractId);
+	
+	List<Claim> findAllByOrderByClaimIdDesc();
 }

--- a/src/main/java/kr/pe/aichief/model/repository/IdentificationRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/IdentificationRepository.java
@@ -1,0 +1,15 @@
+package kr.pe.aichief.model.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pe.aichief.model.entity.Identification;
+
+public interface IdentificationRepository extends JpaRepository<Identification, Integer> {
+
+	Optional<Identification> findByBeneficiary_BeneficiaryId(int id);
+	
+	List<Identification> findAllByOrderByIdentificationIdDesc();
+}

--- a/src/main/java/kr/pe/aichief/model/repository/InsuredRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/InsuredRepository.java
@@ -9,4 +9,6 @@ import kr.pe.aichief.model.entity.Insured;
 public interface InsuredRepository extends JpaRepository<Insured, Integer> {
 	
 	Optional<Insured> findByEmail(String email);
+	
+	Optional<Insured> findByBeneficiary_Email(String email);
 }

--- a/src/main/java/kr/pe/aichief/model/repository/ManagerRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/ManagerRepository.java
@@ -1,7 +1,9 @@
 package kr.pe.aichief.model.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.pe.aichief.model.entity.Manager;
@@ -9,4 +11,7 @@ import kr.pe.aichief.model.entity.Manager;
 public interface ManagerRepository extends JpaRepository<Manager, Integer> {
 	
 	Optional<Manager> findByEmail(String email);
+	
+	@EntityGraph(value = "Manager.assigns")
+	List<Manager> findAll();
 }

--- a/src/main/java/kr/pe/aichief/model/service/MyPageService.java
+++ b/src/main/java/kr/pe/aichief/model/service/MyPageService.java
@@ -60,6 +60,17 @@ public class MyPageService {
 		return dtoConverter.beneficiaryToDto(beneficiary);
 	}
 	
+	public List<BeneficiaryDto> getBeneficiaryWithName(String name) {
+		
+		List<Beneficiary> beneficiaries = beneficiaryRepository.findByName(name);
+		
+		if(beneficiaries.isEmpty()) {
+			throw new EntityNotFoundException("Beneficiary Not Found: " + name);
+		}
+		
+		return beneficiaries.stream().map(beneficiary -> dtoConverter.beneficiaryToDto(beneficiary)).collect(Collectors.toList());
+	}
+	
 	public ManagerDto getManager(String email) {
 		
 		Manager manager = managerRepository.findByEmail(email)

--- a/src/main/java/kr/pe/aichief/util/DtoConverter.java
+++ b/src/main/java/kr/pe/aichief/util/DtoConverter.java
@@ -1,17 +1,28 @@
 package kr.pe.aichief.util;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.stereotype.Component;
 
+import kr.pe.aichief.model.dto.AccidentDto;
+import kr.pe.aichief.model.dto.AccountDto;
+import kr.pe.aichief.model.dto.AnotherSubscribeDto;
+import kr.pe.aichief.model.dto.AssignDto;
 import kr.pe.aichief.model.dto.BeneficiaryDto;
 import kr.pe.aichief.model.dto.ClaimDto;
 import kr.pe.aichief.model.dto.ContractDto;
+import kr.pe.aichief.model.dto.IdentificationDto;
+import kr.pe.aichief.model.dto.InsuranceDto;
+import kr.pe.aichief.model.dto.InsuredDto;
 import kr.pe.aichief.model.dto.ManagerDto;
+import kr.pe.aichief.model.entity.Accident;
+import kr.pe.aichief.model.entity.Account;
+import kr.pe.aichief.model.entity.AnotherSubscribe;
+import kr.pe.aichief.model.entity.Assign;
 import kr.pe.aichief.model.entity.Beneficiary;
 import kr.pe.aichief.model.entity.Claim;
 import kr.pe.aichief.model.entity.Contract;
+import kr.pe.aichief.model.entity.Identification;
+import kr.pe.aichief.model.entity.Insurance;
+import kr.pe.aichief.model.entity.Insured;
 import kr.pe.aichief.model.entity.Manager;
 
 @Component
@@ -19,121 +30,117 @@ public class DtoConverter {
 
 	public BeneficiaryDto beneficiaryToDto(Beneficiary beneficiary) {
 
-		Map<String, String> beneMap = new HashMap<String, String>();
-
-		beneMap.put("beneficiaryId", Integer.toString(beneficiary.getBeneficiaryId()));
-		beneMap.put("email", beneficiary.getEmail());
-		beneMap.put("phoneNumber", beneficiary.getPhoneNumber());
-		beneMap.put("joinDate", beneficiary.getJoinDate().toString());
-		beneMap.put("job", beneficiary.getJob());
-		beneMap.put("landline", beneficiary.getLandline());
-		beneMap.put("address", beneficiary.getAddress());
-		beneMap.put("relationshipWithInsured", beneficiary.getRelationshipWithInsured());
-
-		return BeneficiaryDto.builder().beneficiary(beneMap).build();
+		return BeneficiaryDto.builder()
+				.beneficiaryId(Integer.toString(beneficiary.getBeneficiaryId()))
+				.name(beneficiary.getName())
+				.email(beneficiary.getEmail())
+				.phoneNumber(beneficiary.getPhoneNumber())
+				.joinDate(beneficiary.getJoinDate().toString())
+				.socialSecurityNumber(beneficiary.getSocialSecurityNumber())
+				.job(beneficiary.getJob())
+				.landline(beneficiary.getLandline())
+				.address(beneficiary.getAddress())
+				.relationshipWithInsured(beneficiary.getRelationshipWithInsured())
+				.build();
 	}
 
 	public ClaimDto claimToDto(Claim claim) {
 
-		Map<String, String> claMap = new HashMap<String, String>();
-
-		claMap.put("claimId", Integer.toString(claim.getClaimId()));
-		claMap.put("reasonForPartialClaim", claim.getReasonForPartialClaim());
-		claMap.put("date", claim.getDate().toString());
-
-		Map<String, String> insMap = new HashMap<String, String>();
-
-		insMap.put("insuredId", Integer.toString(claim.getContract().getInsured().getInsuredId()));
-		insMap.put("name", claim.getContract().getInsured().getName());
-		insMap.put("email", claim.getContract().getInsured().getEmail());
-		insMap.put("phoneNumber", claim.getContract().getInsured().getPhoneNumber());
-		insMap.put("joinDate", claim.getContract().getInsured().getJoinDate().toString());
-		insMap.put("job", claim.getContract().getInsured().getJob());
-
-		Map<String, String> benMap = new HashMap<String, String>();
-
-		benMap.put("beneficiaryId", Integer.toString(claim.getContract().getBeneficiary().getBeneficiaryId()));
-		benMap.put("name", claim.getContract().getBeneficiary().getName());
-		benMap.put("email", claim.getContract().getBeneficiary().getEmail());
-		benMap.put("phoneNumber", claim.getContract().getBeneficiary().getPhoneNumber());
-		benMap.put("joinDate", claim.getContract().getBeneficiary().getJoinDate().toString());
-		benMap.put("job", claim.getContract().getBeneficiary().getJob());
-		benMap.put("landline", claim.getContract().getBeneficiary().getLandline());
-		benMap.put("address", claim.getContract().getBeneficiary().getAddress());
-		benMap.put("relationshipWithInsured", claim.getContract().getBeneficiary().getRelationshipWithInsured());
-
-		Map<String, String> insuMap = new HashMap<String, String>();
-
-		insuMap.put("insuranceId", Integer.toString(claim.getContract().getInsurance().getInsuranceId()));
-		insuMap.put("companyName", claim.getContract().getInsurance().getCompanyName());
-		insuMap.put("details", claim.getContract().getInsurance().getDetails());
-
-		Map<String, String> accMap = new HashMap<String, String>();
-
-		accMap.put("accidentId", Integer.toString(claim.getAccident().getAccidentId()));
-		accMap.put("accidentDateTime", claim.getAccident().getDateTime().toString());
-		accMap.put("location", claim.getAccident().getLocation());
-		accMap.put("details", claim.getAccident().getDetails());
-		accMap.put("diseaseName", claim.getAccident().getDiseaseName());
-
-		return ClaimDto.builder().claim(claMap).insured(insMap).beneficiary(benMap).insurance(insuMap).accident(accMap)
+		return ClaimDto.builder()
+				.claimId(Integer.toString(claim.getClaimId()))
+				.reasonForPartialClaim(claim.getReasonForPartialClaim())
+				.date(claim.getDate().toString())
 				.build();
 
 	}
 
 	public ContractDto contractToDto(Contract contract) {
 
-		Map<String, String> conMap = new HashMap<String, String>();
-
-		conMap.put("contractId", Integer.toString(contract.getContractId()));
-		conMap.put("monthlyPremium", Float.toString(contract.getMonthlyPremium()));
-		conMap.put("state", contract.getState());
-
-		Map<String, String> insMap = new HashMap<String, String>();
-
-		insMap.put("insuredId", Integer.toString(contract.getInsured().getInsuredId()));
-		insMap.put("name", contract.getInsured().getName());
-		insMap.put("email", contract.getInsured().getEmail());
-		insMap.put("phoneNumber", contract.getInsured().getPhoneNumber());
-		insMap.put("joinDate", contract.getInsured().getJoinDate().toString());
-		insMap.put("job", contract.getInsured().getJob());
-
-		Map<String, String> benMap = new HashMap<String, String>();
-
-		benMap.put("beneficiaryId", Integer.toString(contract.getBeneficiary().getBeneficiaryId()));
-		benMap.put("name", contract.getBeneficiary().getName());
-		benMap.put("email", contract.getBeneficiary().getEmail());
-		benMap.put("phoneNumber", contract.getBeneficiary().getPhoneNumber());
-		benMap.put("joinDate", contract.getBeneficiary().getJoinDate().toString());
-		benMap.put("job", contract.getBeneficiary().getJob());
-		benMap.put("landline", contract.getBeneficiary().getLandline());
-		benMap.put("address", contract.getBeneficiary().getAddress());
-		benMap.put("relationshipWithInsured", contract.getBeneficiary().getRelationshipWithInsured());
-
-		Map<String, String> insuMap = new HashMap<String, String>();
-
-		insuMap.put("insuranceId", Integer.toString(contract.getInsurance().getInsuranceId()));
-		insuMap.put("companyName", contract.getInsurance().getCompanyName());
-		insuMap.put("details", contract.getInsurance().getDetails());
-		
 		return ContractDto.builder()
-				.contract(conMap)
-				.insured(insMap)
-				.beneficiary(benMap)
-				.insurance(insuMap)
+				.contractId(Integer.toString(contract.getContractId()))
+				.monthlyPremium(Float.toString(contract.getMonthlyPremium()))
+				.state(contract.getState())
 				.build();
 	}
 
 	public ManagerDto managerToDto(Manager manager) {
 
-		Map<String, String> manaMap = new HashMap<String, String>();
-
-		manaMap.put("managerId", Integer.toString(manager.getManagerId()));
-		manaMap.put("name", manager.getName());
-		manaMap.put("email", manager.getEmail());
-		manaMap.put("phoneNumber", manager.getPhoneNumber());
-		manaMap.put("joinDate", manager.getJoinDate().toString());
-
-		return ManagerDto.builder().manager(manaMap).build();
+		return ManagerDto.builder()
+				.managerId(Integer.toBinaryString(manager.getManagerId()))
+				.name(manager.getName())
+				.email(manager.getEmail())
+				.phoneNumber(manager.getPhoneNumber())
+				.joinDate(manager.getJoinDate().toString())
+				.build();
+	}
+	
+	public IdentificationDto identificationToDto(Identification iden) {
+		
+		return IdentificationDto.builder()
+				.identificationId(Integer.toString(iden.getIdentificationId()))
+				.number(iden.getNumber())
+				.serialNumber(iden.getSerialNumber())
+				.issueDate(iden.getIssueDate().toString())
+				.issueBy(iden.getIssueBy())
+				.build();
+	}
+	
+	public AnotherSubscribeDto anotherSubscribeToDto(AnotherSubscribe as) {
+		
+		return AnotherSubscribeDto.builder()
+				.anotherSubscribeId(Integer.toString(as.getAnotherSubscribeId()))
+				.companyName(as.getCompanyName())
+				.number(Integer.toString(as.getNumber()))
+				.build();
+	}
+	
+	public AccountDto accountToDto(Account acc) {
+		
+		return AccountDto.builder()
+				.accountId(Integer.toString(acc.getAccountId()))
+				.bankName(acc.getBankName())
+				.number(acc.getNumber())
+				.holder(acc.getHolder())
+				.build();
+	}
+	
+	public InsuredDto insuredToDto(Insured ins) {
+		
+		return InsuredDto.builder()
+				.insuredId(Integer.toString(ins.getInsuredId()))
+				.name(ins.getName())
+				.email(ins.getEmail())
+				.phoneNumber(ins.getPhoneNumber())
+				.joinDate(ins.getJoinDate().toString())
+				.socialSecurityNumber(ins.getSocialSecurityNumber())
+				.job(ins.getJob())
+				.build();
+	}
+	
+	public InsuranceDto insuranceToDto(Insurance ins) {
+		
+		return InsuranceDto.builder()
+				.insuranceId(Integer.toString(ins.getInsuranceId()))
+				.companyName(ins.getCompanyName())
+				.details(ins.getDetails())
+				.build();
+	}
+	
+	public AccidentDto accidentToDto(Accident acc) {
+		
+		return AccidentDto.builder()
+				.accidentId(Integer.toString(acc.getAccidentId()))
+				.dateTime(acc.getDateTime().toString())
+				.location(acc.getLocation())
+				.details(acc.getDetails())
+				.diseaseName(acc.getDiseaseName())
+				.build();
+	}
+	
+	public AssignDto assignToDto(Assign ass) {
+		
+		return AssignDto.builder()
+				.assignId(Integer.toString(ass.getAssignId()))
+				.build();
 	}
 }

--- a/src/main/java/kr/pe/aichief/util/ManagerComparator.java
+++ b/src/main/java/kr/pe/aichief/util/ManagerComparator.java
@@ -1,0 +1,18 @@
+package kr.pe.aichief.util;
+
+import java.util.Comparator;
+
+import org.springframework.stereotype.Component;
+
+import kr.pe.aichief.model.entity.Manager;
+
+@Component
+public class ManagerComparator implements Comparator<Manager> {
+
+	@Override
+	public int compare(Manager o1, Manager o2) {
+		
+		return o1.getAssigns().size() - o2.getAssigns().size();
+	}
+
+}

--- a/src/main/java/kr/pe/aichief/util/MyConverter.java
+++ b/src/main/java/kr/pe/aichief/util/MyConverter.java
@@ -1,0 +1,13 @@
+package kr.pe.aichief.util;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyConverter {
+
+	public String spaceJoiner(List<String> ls) {
+		return String.join(" ", ls);
+	}
+}

--- a/src/test/java/kr/pe/aichief/model/service/MyPageServiceTest.java
+++ b/src/test/java/kr/pe/aichief/model/service/MyPageServiceTest.java
@@ -1,25 +1,58 @@
 package kr.pe.aichief.model.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Disabled;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kr.pe.aichief.model.entity.Claim;
+import kr.pe.aichief.model.repository.ClaimRepository;
+import kr.pe.aichief.model.repository.ManagerRepository;
+import kr.pe.aichief.util.DtoConverter;
 
 @Disabled
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
+@SpringBootTest
 public class MyPageServiceTest {
 	
-	// 수익자
+	@Autowired
+	private DtoConverter dtoConverter;
 	
-	// 내 정보 수정
-	// 내 계약 조회
-	// 내 청구 조회
+	@Autowired
+	private ManagerRepository managerRepository;
 	
-	// 담당자
+	@Autowired
+	private ClaimRepository claimRepository;
 	
-	// 내 정보 조회
-	// 내 정보 수정
-	// 내 고객 조회
-	// 내 청구 조회
+	private String managerEmail = "kim@test.com";
+	
+	private String beneficiaryEmail = "park@test.com";
+	
+	// 내 정보 수정 - 수익자
+	
+	// 내 계약 조회 - 수익자
+	
+	// 내 청구 조회 - 수익자
+	@Disabled
+	@Test
+	void getAllBeneficiaryClaimsTest() {
+		
+		List<Claim> claims = claimRepository.findByContract_Beneficiary_Email(beneficiaryEmail);
+		System.out.println(claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList()).toString());
+	}
+	
+	// 내 정보 조회 - 담당자
+	@Disabled
+	@Test
+	void getManagerTest() {
+		System.out.println(dtoConverter.managerToDto(managerRepository.findByEmail(managerEmail).get()));
+	}
+	
+	// 내 정보 수정 - 담당자
+	
+	// 내 고객 조회 - 담당자
+	
+	// 내 청구 조회 - 담당자
 }

--- a/src/test/java/kr/pe/aichief/util/ManagerComparatorTest.java
+++ b/src/test/java/kr/pe/aichief/util/ManagerComparatorTest.java
@@ -1,0 +1,47 @@
+package kr.pe.aichief.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import kr.pe.aichief.model.entity.Assign;
+import kr.pe.aichief.model.entity.Manager;
+
+@Disabled
+@SpringBootTest
+public class ManagerComparatorTest {
+	
+	@Autowired
+	private ManagerComparator managerComparator;
+	
+	@Test
+	void comparatorTest() {
+		List<Assign> assigns1 = new ArrayList<Assign>();
+		List<Assign> assigns2 = new ArrayList<Assign>();
+		
+		assigns1.add(Assign.builder().build());
+		assigns1.add(Assign.builder().build());
+		
+		assigns2.add(Assign.builder().build());
+		
+		Manager manager1 = Manager.builder().assigns(assigns1).build();
+		Manager manager2 = Manager.builder().assigns(assigns2).build();
+		
+		List<Manager> managers = new ArrayList<Manager>();
+		
+		managers.add(manager1);
+		managers.add(manager2);
+		
+		managers.forEach(manager -> System.out.println(manager.getAssigns().size()));
+		
+		Collections.sort(managers, managerComparator);
+		
+		managers.forEach(manager -> System.out.println(manager.getAssigns().size()));
+	}
+
+}


### PR DESCRIPTION
# 📑 개요
청구 접수 기능을 추가함

# 📌 내용
- 청구서 손글씨 인식 API에 인식 요청
- 계약 시 DB에 저장한 계약 관련 정보(피보험자, 수익자, 계약된 보험) 조회
- 인식 결과 중 계약 관련 정보로 대체할 수 있는 것은 대체하며, 그 외 청구서에만 존재하는 정보(사고 관련 정보, 타 보험사 가입 여부, 보험금 지급 계좌 정보)는 그대로 저장함
- 가장 적은 수의 보험 청구 접수를 맡은 담당자를 배정함
- 청구 접수 결과를 사용자에게 반환함