### PR TITLE
청구 및 계약 내역 상세 조회 추가

### DIFF
--- a/src/main/java/kr/pe/aichief/model/dto/BeneficiaryDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/BeneficiaryDto.java
@@ -36,4 +36,5 @@ public class BeneficiaryDto {
 	
 	private String relationshipWithInsured;
 	
+	private String role;
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ContractResult.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ContractResult.java
@@ -10,27 +10,18 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Getter
 @Setter
+@Getter
 @ToString
 
-public class ClaimResult {
-
-	private ClaimDto claim;
+public class ContractResult {
+	
+	private ContractDto contract;
 	
 	private InsuredDto insured;
 	
 	private BeneficiaryDto beneficiary;
 	
-	private IdentificationDto identification;
-	
-	private AnotherSubscribeDto anotherSubscribe;
-	
-	private AccountDto account;
-	
-	private AccidentDto accident;
-	
-	private ContractDto contract;
-	
 	private InsuranceDto insurance;
+
 }

--- a/src/main/java/kr/pe/aichief/model/dto/ManagerDto.java
+++ b/src/main/java/kr/pe/aichief/model/dto/ManagerDto.java
@@ -25,4 +25,6 @@ public class ManagerDto {
 	private String phoneNumber;
 	
 	private String joinDate;
+	
+	private String role;
 }

--- a/src/main/java/kr/pe/aichief/model/repository/AccidentRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/AccidentRepository.java
@@ -12,4 +12,6 @@ public interface AccidentRepository extends JpaRepository<Accident, Integer> {
 	List<Accident> findAllByOrderByAccidentIdDesc();
 	
 	Optional<Accident> findByClaim_Contract_ContractId(int id);
+	
+	Optional<Accident> findByClaim_ClaimId(int id);
 }

--- a/src/main/java/kr/pe/aichief/model/repository/BeneficiaryRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/BeneficiaryRepository.java
@@ -16,4 +16,6 @@ public interface BeneficiaryRepository extends JpaRepository<Beneficiary, Intege
 	
 	@EntityGraph(value = "Beneficiary.anotherSubscribes")
 	Optional<Beneficiary> findByBeneficiaryId(int id);
+	
+	Optional<Beneficiary> findByContracts_ContractId(int id);
 }

--- a/src/main/java/kr/pe/aichief/model/repository/ContractRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/ContractRepository.java
@@ -1,6 +1,7 @@
 package kr.pe.aichief.model.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import kr.pe.aichief.model.entity.Contract;
 public interface ContractRepository extends JpaRepository<Contract, Integer> {
 
 	List<Contract> findByBeneficiary_Email(String email);
+	
+	Optional<Contract> findByClaim_ClaimId(int id);
 }

--- a/src/main/java/kr/pe/aichief/model/repository/InsuranceRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/InsuranceRepository.java
@@ -1,0 +1,12 @@
+package kr.pe.aichief.model.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.pe.aichief.model.entity.Insurance;
+
+public interface InsuranceRepository extends JpaRepository<Insurance, Integer> {
+
+	Optional<Insurance> findByContracts_ContractId(int id);
+}

--- a/src/main/java/kr/pe/aichief/model/repository/InsuredRepository.java
+++ b/src/main/java/kr/pe/aichief/model/repository/InsuredRepository.java
@@ -11,4 +11,6 @@ public interface InsuredRepository extends JpaRepository<Insured, Integer> {
 	Optional<Insured> findByEmail(String email);
 	
 	Optional<Insured> findByBeneficiary_Email(String email);
+	
+	Optional<Insured> findByContracts_ContractId(int id);
 }

--- a/src/main/java/kr/pe/aichief/model/service/MyPageService.java
+++ b/src/main/java/kr/pe/aichief/model/service/MyPageService.java
@@ -1,5 +1,6 @@
 package kr.pe.aichief.model.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -7,9 +8,17 @@ import javax.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Service;
 
+import kr.pe.aichief.model.dto.AccidentDto;
+import kr.pe.aichief.model.dto.AccountDto;
+import kr.pe.aichief.model.dto.AnotherSubscribeDto;
 import kr.pe.aichief.model.dto.BeneficiaryDto;
 import kr.pe.aichief.model.dto.ClaimDto;
+import kr.pe.aichief.model.dto.ClaimResult;
 import kr.pe.aichief.model.dto.ContractDto;
+import kr.pe.aichief.model.dto.ContractResult;
+import kr.pe.aichief.model.dto.IdentificationDto;
+import kr.pe.aichief.model.dto.InsuranceDto;
+import kr.pe.aichief.model.dto.InsuredDto;
 import kr.pe.aichief.model.dto.ManagerDto;
 import kr.pe.aichief.model.entity.Assign;
 import kr.pe.aichief.model.entity.Beneficiary;
@@ -17,10 +26,16 @@ import kr.pe.aichief.model.entity.Claim;
 import kr.pe.aichief.model.entity.Contract;
 import kr.pe.aichief.model.entity.Manager;
 import kr.pe.aichief.model.entity.Member;
+import kr.pe.aichief.model.repository.AccidentRepository;
+import kr.pe.aichief.model.repository.AccountRepository;
+import kr.pe.aichief.model.repository.AnotherSubscribeRepository;
 import kr.pe.aichief.model.repository.AssignRepository;
 import kr.pe.aichief.model.repository.BeneficiaryRepository;
 import kr.pe.aichief.model.repository.ClaimRepository;
 import kr.pe.aichief.model.repository.ContractRepository;
+import kr.pe.aichief.model.repository.IdentificationRepository;
+import kr.pe.aichief.model.repository.InsuranceRepository;
+import kr.pe.aichief.model.repository.InsuredRepository;
 import kr.pe.aichief.model.repository.ManagerRepository;
 import kr.pe.aichief.model.repository.MemberRepository;
 import kr.pe.aichief.util.DtoConverter;
@@ -44,6 +59,23 @@ public class MyPageService {
 	
 	private final AssignRepository assignRepository;
 	
+	private final AccidentRepository accidentRepository;
+	
+	private final InsuredRepository insuredRepository;
+	
+	private final IdentificationRepository identificationRepository;
+	
+	private final AnotherSubscribeRepository anotherSubscribeRepository;
+	
+	private final AccountRepository accountRepository;
+	
+	private final InsuranceRepository insuranceRepository;
+	
+	/**
+	 * 회원의 역할 조회
+	 * @param email
+	 * @return role
+	 */
 	public String getMemberRole(String email) {
 		
 		Member member = memberRepository.findByEmail(email)
@@ -52,14 +84,29 @@ public class MyPageService {
 		return member.getRole();
 	}
 	
+	/**
+	 * 이메일로 수익자 개인 정보 조회
+	 * @param email
+	 * @return beneficiary
+	 */
 	public BeneficiaryDto getBeneficiary(String email) {
 		
 		Beneficiary beneficiary = beneficiaryRepository.findByEmail(email)
 				.orElseThrow(() -> new EntityNotFoundException("Beneficiary Not Found: " + email));
 		
-		return dtoConverter.beneficiaryToDto(beneficiary);
+		BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiary);
+		
+		beneficiaryDto.setRole(memberRepository.findByEmail(email)
+				.orElseThrow(() -> new EntityNotFoundException("Member Not Found")).getRole());
+		
+		return beneficiaryDto;
 	}
 	
+	/**
+	 * 이름으로 수익자들의 개인 정보 조회
+	 * @param name
+	 * @return beneficiaries
+	 */
 	public List<BeneficiaryDto> getBeneficiaryWithName(String name) {
 		
 		List<Beneficiary> beneficiaries = beneficiaryRepository.findByName(name);
@@ -71,15 +118,30 @@ public class MyPageService {
 		return beneficiaries.stream().map(beneficiary -> dtoConverter.beneficiaryToDto(beneficiary)).collect(Collectors.toList());
 	}
 	
+	/**
+	 * 이메일로 담당자 개인 정보 조회
+	 * @param email
+	 * @return manager
+	 */
 	public ManagerDto getManager(String email) {
 		
 		Manager manager = managerRepository.findByEmail(email)
 				.orElseThrow(() -> new EntityNotFoundException("Manager Not Found: " + email));
 		
-		return dtoConverter.managerToDto(manager);
+		ManagerDto managerDto = dtoConverter.managerToDto(manager);
+		
+		managerDto.setRole(memberRepository.findByEmail(email)
+				.orElseThrow(() -> new EntityNotFoundException("Member Not Found")).getRole());
+		
+		return managerDto;
 	}
 	
-	public List<ClaimDto> getAllBeneficiaryClaims(String email) {
+	/**
+	 * 이메일로 수익자가 청구한 모든 청구 내역 조회
+	 * @param email
+	 * @return claims
+	 */
+	public List<ClaimResult> getAllBeneficiaryClaims(String email) {
 		
 		List<Claim> claims = claimRepository.findByContract_Beneficiary_Email(email);
 		
@@ -87,10 +149,74 @@ public class MyPageService {
 			throw new EntityNotFoundException("Claims Not Found");
 		}
 		
-		return claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList());
+		List<ClaimResult> claimResults = new ArrayList<ClaimResult>();
+		
+		List<ClaimDto> claimDtos = claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList());
+		for(ClaimDto dto : claimDtos) {
+			
+			// 계약
+			ContractDto contractDto = dtoConverter.contractToDto(
+					contractRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Contract not found")));
+
+			// 사고
+			AccidentDto accidentDto = dtoConverter.accidentToDto(
+					accidentRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Accident not found")));
+
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(insuredRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insured not found")));
+
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiaryRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Beneficiary not found")));
+
+			// 신분증
+			IdentificationDto identificationDto = dtoConverter.identificationToDto(identificationRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Identification not found")));
+
+			// 타사 가입
+			AnotherSubscribeDto anotherSubscribeDto = dtoConverter.anotherSubscribeToDto(anotherSubscribeRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException(
+							"Get all beneficiary claims: AnotherSubscribe not found")));
+
+			// 계좌
+			AccountDto accountDto = dtoConverter.accountToDto(accountRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Account not found")));
+
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(insuranceRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insurance not found")));
+
+			claimResults.add(ClaimResult.builder()
+					.claim(dto)
+					.insured(insuredDto)
+					.beneficiary(beneficiaryDto)
+					.identification(identificationDto)
+					.anotherSubscribe(anotherSubscribeDto)
+					.account(accountDto)
+					.accident(accidentDto)
+					.contract(contractDto)
+					.insurance(insuranceDto)
+					.build());
+		}
+		
+		return claimResults;
 	}
 	
-	public List<ClaimDto> getAllManagerClaims(String email) {
+	/**
+	 * 이메일로 담당자가 배정 받은 모든 청구 내역 조회
+	 * @param email
+	 * @return claims
+	 */
+	public List<ClaimResult> getAllManagerClaims(String email) {
 		
 		List<Claim> claims = claimRepository.findByAssign_Manager_Email(email);
 		
@@ -98,10 +224,75 @@ public class MyPageService {
 			throw new EntityNotFoundException("Claims Not Found");
 		}
 		
-		return claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList());
+		List<ClaimResult> claimResults = new ArrayList<ClaimResult>();
+		
+		List<ClaimDto> claimDtos = claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList());
+		
+		for(ClaimDto dto : claimDtos) {
+			
+			// 계약
+			ContractDto contractDto = dtoConverter.contractToDto(
+					contractRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Contract not found")));
+
+			// 사고
+			AccidentDto accidentDto = dtoConverter.accidentToDto(
+					accidentRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Accident not found")));
+
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(insuredRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insured not found")));
+
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiaryRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Beneficiary not found")));
+
+			// 신분증
+			IdentificationDto identificationDto = dtoConverter.identificationToDto(identificationRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Identification not found")));
+
+			// 타사 가입
+			AnotherSubscribeDto anotherSubscribeDto = dtoConverter.anotherSubscribeToDto(anotherSubscribeRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException(
+							"Get all beneficiary claims: AnotherSubscribe not found")));
+
+			// 계좌
+			AccountDto accountDto = dtoConverter.accountToDto(accountRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Account not found")));
+
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(insuranceRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insurance not found")));
+
+			claimResults.add(ClaimResult.builder()
+					.claim(dto)
+					.insured(insuredDto)
+					.beneficiary(beneficiaryDto)
+					.identification(identificationDto)
+					.anotherSubscribe(anotherSubscribeDto)
+					.account(accountDto)
+					.accident(accidentDto)
+					.contract(contractDto)
+					.insurance(insuranceDto)
+					.build());
+		}
+		
+		return claimResults;
 	}
 	
-	public List<ContractDto> getAllBeneficiaryContracts(String email) {
+	/**
+	 * 이메일로 수익자의 모든 계약 내역 조회
+	 * @param email
+	 * @return contracts
+	 */
+	public List<ContractResult> getAllBeneficiaryContracts(String email) {
 		
 		List<Contract> contracts = contractRepository.findByBeneficiary_Email(email);
 		
@@ -109,9 +300,40 @@ public class MyPageService {
 			throw new EntityNotFoundException("Contracts Not Found");
 		}
 		
-		return contracts.stream().map(contract -> dtoConverter.contractToDto(contract)).collect(Collectors.toList());
+		List<ContractResult> contractResults = new ArrayList<ContractResult>();
+		
+		List<ContractDto> contractDtos = contracts.stream().map(contract -> dtoConverter.contractToDto(contract)).collect(Collectors.toList());
+		
+		for(ContractDto dto : contractDtos) {
+			
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(insuredRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary's contracts: Insured not found")));
+			
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiaryRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary's contracts: Beneficiary not found")));
+			
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(insuranceRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary's contracts: Insurance not found")));
+			
+			contractResults.add(ContractResult.builder()
+					.contract(dto)
+					.insured(insuredDto)
+					.beneficiary(beneficiaryDto)
+					.insurance(insuranceDto)
+					.build());
+		}
+		
+		return contractResults;
 	}
 	
+	/**
+	 * 이메일로 담당자가 배정 받은 모든 수익자들의 개인 정보 조회
+	 * @param email
+	 * @return
+	 */
 	public List<BeneficiaryDto> getAllManagerBeneficiaries(String email) {
 		
 		List<Assign> assigns = assignRepository.findByManager_Email(email);

--- a/src/main/java/kr/pe/aichief/util/DtoConverter.java
+++ b/src/main/java/kr/pe/aichief/util/DtoConverter.java
@@ -1,5 +1,7 @@
 package kr.pe.aichief.util;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import kr.pe.aichief.model.dto.AccidentDto;
@@ -37,10 +39,10 @@ public class DtoConverter {
 				.phoneNumber(beneficiary.getPhoneNumber())
 				.joinDate(beneficiary.getJoinDate().toString())
 				.socialSecurityNumber(beneficiary.getSocialSecurityNumber())
-				.job(beneficiary.getJob())
-				.landline(beneficiary.getLandline())
+				.job(Optional.ofNullable(beneficiary.getJob()).orElse("-"))
+				.landline(Optional.ofNullable(beneficiary.getLandline()).orElse("-"))
 				.address(beneficiary.getAddress())
-				.relationshipWithInsured(beneficiary.getRelationshipWithInsured())
+				.relationshipWithInsured(Optional.ofNullable(beneficiary.getRelationshipWithInsured()).orElse("-"))
 				.build();
 	}
 
@@ -48,19 +50,24 @@ public class DtoConverter {
 
 		return ClaimDto.builder()
 				.claimId(Integer.toString(claim.getClaimId()))
-				.reasonForPartialClaim(claim.getReasonForPartialClaim())
+				.reasonForPartialClaim(Optional.ofNullable(claim.getReasonForPartialClaim()).orElse("-"))
 				.date(claim.getDate().toString())
 				.build();
 
 	}
 
 	public ContractDto contractToDto(Contract contract) {
-
-		return ContractDto.builder()
+		
+		ContractDto dto = ContractDto.builder()
 				.contractId(Integer.toString(contract.getContractId()))
-				.monthlyPremium(Float.toString(contract.getMonthlyPremium()))
-				.state(contract.getState())
+				.state(Optional.ofNullable(contract.getState()).orElse("-"))
 				.build();
+		
+		if(!Optional.ofNullable(contract.getMonthlyPremium()).isEmpty()) {
+			dto.setMonthlyPremium(Float.toString(contract.getMonthlyPremium()));
+		}
+
+		return dto;
 	}
 
 	public ManagerDto managerToDto(Manager manager) {
@@ -76,13 +83,18 @@ public class DtoConverter {
 	
 	public IdentificationDto identificationToDto(Identification iden) {
 		
-		return IdentificationDto.builder()
+		IdentificationDto dto = IdentificationDto.builder()
 				.identificationId(Integer.toString(iden.getIdentificationId()))
 				.number(iden.getNumber())
-				.serialNumber(iden.getSerialNumber())
-				.issueDate(iden.getIssueDate().toString())
-				.issueBy(iden.getIssueBy())
+				.serialNumber(Optional.ofNullable(iden.getSerialNumber()).orElse("-"))
+				.issueBy(Optional.ofNullable(iden.getIssueBy()).orElse("-"))
 				.build();
+		
+		if(!Optional.ofNullable(iden.getIssueDate()).isEmpty()) {
+			dto.setIssueDate(iden.getIssueDate().toString());
+		}
+		
+		return dto;
 	}
 	
 	public AnotherSubscribeDto anotherSubscribeToDto(AnotherSubscribe as) {
@@ -90,7 +102,7 @@ public class DtoConverter {
 		return AnotherSubscribeDto.builder()
 				.anotherSubscribeId(Integer.toString(as.getAnotherSubscribeId()))
 				.companyName(as.getCompanyName())
-				.number(Integer.toString(as.getNumber()))
+				.number(Integer.toString(Optional.ofNullable(as.getNumber()).orElse(0)))
 				.build();
 	}
 	
@@ -113,7 +125,7 @@ public class DtoConverter {
 				.phoneNumber(ins.getPhoneNumber())
 				.joinDate(ins.getJoinDate().toString())
 				.socialSecurityNumber(ins.getSocialSecurityNumber())
-				.job(ins.getJob())
+				.job(Optional.ofNullable(ins.getJob()).orElse("-"))
 				.build();
 	}
 	
@@ -122,7 +134,7 @@ public class DtoConverter {
 		return InsuranceDto.builder()
 				.insuranceId(Integer.toString(ins.getInsuranceId()))
 				.companyName(ins.getCompanyName())
-				.details(ins.getDetails())
+				.details(Optional.ofNullable(ins.getDetails()).orElse("-"))
 				.build();
 	}
 	
@@ -131,9 +143,9 @@ public class DtoConverter {
 		return AccidentDto.builder()
 				.accidentId(Integer.toString(acc.getAccidentId()))
 				.dateTime(acc.getDateTime().toString())
-				.location(acc.getLocation())
+				.location(Optional.ofNullable(acc.getLocation()).orElse("-"))
 				.details(acc.getDetails())
-				.diseaseName(acc.getDiseaseName())
+				.diseaseName(Optional.ofNullable(acc.getDiseaseName()).orElse("-"))
 				.build();
 	}
 	

--- a/src/test/java/kr/pe/aichief/model/service/MyPageServiceTest.java
+++ b/src/test/java/kr/pe/aichief/model/service/MyPageServiceTest.java
@@ -1,58 +1,284 @@
 package kr.pe.aichief.model.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.persistence.EntityNotFoundException;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import kr.pe.aichief.model.dto.AccidentDto;
+import kr.pe.aichief.model.dto.AccountDto;
+import kr.pe.aichief.model.dto.AnotherSubscribeDto;
+import kr.pe.aichief.model.dto.BeneficiaryDto;
+import kr.pe.aichief.model.dto.ClaimDto;
+import kr.pe.aichief.model.dto.ClaimResult;
+import kr.pe.aichief.model.dto.ContractDto;
+import kr.pe.aichief.model.dto.ContractResult;
+import kr.pe.aichief.model.dto.IdentificationDto;
+import kr.pe.aichief.model.dto.InsuranceDto;
+import kr.pe.aichief.model.dto.InsuredDto;
 import kr.pe.aichief.model.entity.Claim;
+import kr.pe.aichief.model.entity.Contract;
+import kr.pe.aichief.model.repository.AccidentRepository;
+import kr.pe.aichief.model.repository.AccountRepository;
+import kr.pe.aichief.model.repository.AnotherSubscribeRepository;
+import kr.pe.aichief.model.repository.BeneficiaryRepository;
 import kr.pe.aichief.model.repository.ClaimRepository;
+import kr.pe.aichief.model.repository.ContractRepository;
+import kr.pe.aichief.model.repository.IdentificationRepository;
+import kr.pe.aichief.model.repository.InsuranceRepository;
+import kr.pe.aichief.model.repository.InsuredRepository;
 import kr.pe.aichief.model.repository.ManagerRepository;
 import kr.pe.aichief.util.DtoConverter;
 
 @Disabled
 @SpringBootTest
 public class MyPageServiceTest {
-	
+
 	@Autowired
 	private DtoConverter dtoConverter;
-	
+
+	@Autowired
+	private ContractRepository contractRepository;
+
 	@Autowired
 	private ManagerRepository managerRepository;
-	
+
 	@Autowired
 	private ClaimRepository claimRepository;
-	
+
+	@Autowired
+	private BeneficiaryRepository beneficiaryRepository;
+
+	@Autowired
+	private IdentificationRepository identificationRepository;
+
+	@Autowired
+	private AnotherSubscribeRepository anotherSubscribeRepository;
+
+	@Autowired
+	private AccountRepository accountRepository;
+
+	@Autowired
+	private AccidentRepository accidentRepository;
+
+	@Autowired
+	private InsuredRepository insuredRepository;
+
+	@Autowired
+	private InsuranceRepository insuranceRepository;
+
 	private String managerEmail = "kim@test.com";
-	
+
 	private String beneficiaryEmail = "park@test.com";
-	
+
 	// 내 정보 수정 - 수익자
-	
+
 	// 내 계약 조회 - 수익자
-	
+	@Disabled
+	@Test
+	void getAllBeneficiaryContractsTest() {
+
+		String email = beneficiaryEmail;
+
+		List<Contract> contracts = contractRepository.findByBeneficiary_Email(email);
+
+		if (contracts.isEmpty()) {
+			throw new EntityNotFoundException("Contracts Not Found");
+		}
+
+		List<ContractResult> contractResults = new ArrayList<ContractResult>();
+
+		List<ContractDto> contractDtos = contracts.stream().map(contract -> dtoConverter.contractToDto(contract))
+				.collect(Collectors.toList());
+
+		for (ContractDto dto : contractDtos) {
+
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(
+					insuredRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary's contracts: Insured not found")));
+
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(
+					beneficiaryRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId()))
+							.orElseThrow(() -> new EntityNotFoundException(
+									"Get all beneficiary's contracts: Beneficiary not found")));
+
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(
+					insuranceRepository.findByContracts_ContractId(Integer.parseInt(dto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary's contracts: Insurance not found")));
+
+			contractResults.add(ContractResult.builder().contract(dto).insured(insuredDto).beneficiary(beneficiaryDto)
+					.insurance(insuranceDto).build());
+		}
+
+		contractResults.forEach(cr -> System.out.println(cr));
+	}
+
 	// 내 청구 조회 - 수익자
 	@Disabled
 	@Test
 	void getAllBeneficiaryClaimsTest() {
-		
-		List<Claim> claims = claimRepository.findByContract_Beneficiary_Email(beneficiaryEmail);
-		System.out.println(claims.stream().map(claim -> dtoConverter.claimToDto(claim)).collect(Collectors.toList()).toString());
+
+		String email = beneficiaryEmail;
+
+		List<Claim> claims = claimRepository.findByContract_Beneficiary_Email(email);
+
+		if (claims.isEmpty()) {
+			throw new EntityNotFoundException("Claims Not Found");
+		}
+
+		List<ClaimResult> claimResults = new ArrayList<ClaimResult>();
+
+		List<ClaimDto> claimDtos = claims.stream().map(claim -> dtoConverter.claimToDto(claim))
+				.collect(Collectors.toList());
+		for (ClaimDto dto : claimDtos) {
+
+			// 계약
+			ContractDto contractDto = dtoConverter.contractToDto(
+					contractRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Contract not found")));
+
+			// 사고
+			AccidentDto accidentDto = dtoConverter.accidentToDto(
+					accidentRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Accident not found")));
+
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(insuredRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insured not found")));
+
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiaryRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Beneficiary not found")));
+
+			System.out.println(beneficiaryDto);
+
+			// 신분증
+			IdentificationDto identificationDto = dtoConverter.identificationToDto(identificationRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Identification not found")));
+
+			// 타사 가입
+			AnotherSubscribeDto anotherSubscribeDto = dtoConverter.anotherSubscribeToDto(anotherSubscribeRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException(
+							"Get all beneficiary claims: AnotherSubscribe not found")));
+
+			// 계좌
+			AccountDto accountDto = dtoConverter.accountToDto(accountRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Account not found")));
+
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(insuranceRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insurance not found")));
+
+			claimResults.add(ClaimResult.builder().claim(dto).insured(insuredDto).beneficiary(beneficiaryDto)
+					.identification(identificationDto).anotherSubscribe(anotherSubscribeDto).account(accountDto)
+					.accident(accidentDto).contract(contractDto).insurance(insuranceDto).build());
+		}
+
+		System.out.println(claimResults);
 	}
-	
+
 	// 내 정보 조회 - 담당자
 	@Disabled
 	@Test
 	void getManagerTest() {
 		System.out.println(dtoConverter.managerToDto(managerRepository.findByEmail(managerEmail).get()));
 	}
-	
+
 	// 내 정보 수정 - 담당자
-	
+
 	// 내 고객 조회 - 담당자
-	
+
 	// 내 청구 조회 - 담당자
+	@Disabled
+	@Test
+	void getAllManagerClaimsTest() {
+		String email = managerEmail;
+
+		List<Claim> claims = claimRepository.findByAssign_Manager_Email(email);
+
+		if (claims.isEmpty()) {
+			throw new EntityNotFoundException("Claims Not Found");
+		}
+
+		List<ClaimResult> claimResults = new ArrayList<ClaimResult>();
+
+		List<ClaimDto> claimDtos = claims.stream().map(claim -> dtoConverter.claimToDto(claim))
+				.collect(Collectors.toList());
+
+		for (ClaimDto dto : claimDtos) {
+
+			// 계약
+			ContractDto contractDto = dtoConverter.contractToDto(
+					contractRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Contract not found")));
+
+			// 사고
+			AccidentDto accidentDto = dtoConverter.accidentToDto(
+					accidentRepository.findByClaim_ClaimId(Integer.parseInt(dto.getClaimId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Accident not found")));
+
+			// 피보험자
+			InsuredDto insuredDto = dtoConverter.insuredToDto(insuredRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insured not found")));
+
+			// 수익자
+			BeneficiaryDto beneficiaryDto = dtoConverter.beneficiaryToDto(beneficiaryRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Beneficiary not found")));
+
+			// 신분증
+			IdentificationDto identificationDto = dtoConverter.identificationToDto(identificationRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId())).orElseThrow(
+							() -> new EntityNotFoundException("Get all beneficiary claims: Identification not found")));
+
+			// 타사 가입
+			AnotherSubscribeDto anotherSubscribeDto = dtoConverter.anotherSubscribeToDto(anotherSubscribeRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException(
+							"Get all beneficiary claims: AnotherSubscribe not found")));
+
+			// 계좌
+			AccountDto accountDto = dtoConverter.accountToDto(accountRepository
+					.findByBeneficiary_BeneficiaryId(Integer.parseInt(beneficiaryDto.getBeneficiaryId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Account not found")));
+
+			// 보험
+			InsuranceDto insuranceDto = dtoConverter.insuranceToDto(insuranceRepository
+					.findByContracts_ContractId(Integer.parseInt(contractDto.getContractId()))
+					.orElseThrow(() -> new EntityNotFoundException("Get all beneficiary claims: Insurance not found")));
+
+			claimResults.add(ClaimResult.builder().claim(dto).insured(insuredDto).beneficiary(beneficiaryDto)
+					.identification(identificationDto).anotherSubscribe(anotherSubscribeDto).account(accountDto)
+					.accident(accidentDto).contract(contractDto).insurance(insuranceDto).build());
+		}
+
+		claimResults.forEach(cr -> System.out.println("결과 :" + cr));
+	}
+
+	// 계약 번호로 피보험자 조회
+	@Disabled
+	@Test
+	void getInsuredWithContractIdTest() {
+
+		int contractId = 1;
+
+		System.out.println(dtoConverter.insuredToDto(insuredRepository.findByContracts_ContractId(contractId)
+				.orElseThrow(() -> new EntityNotFoundException("Get insured with contract id: Failed"))));
+	}
 }


### PR DESCRIPTION
# 📑 개요
청구 및 계약 내역 조회 시 상세 조회가 가능하도록 기존 조회 기능 수정 및 추가

# 📌 내용
- 청구 내역 조회 시 청구, 계약, 사고 내용, 피보험자, 수익자, 수익자 신분증, 수익자 타사 가입 여부, 수익자 계좌, 계약된 보험 정보를 포함하도록 변경함
- 계약 내역 조회 시 계약, 피보험자, 수익자, 계약된 보험 정보를 포함하도록 변경함

# 💥 Error와 Cause
- Error : Entity instance를 Dto instance로 변환 시 NPE(NullPointerException) 발생
- Cause : Entity instance에 nullable한 instance variable이 있기 때문에 값이 null일 경우 NPE가 발생함

# 💡 해결
- Entity instance의 nullable한 instance variable은 Dto instance의 instance variable로 변환 시 Optional을 이용해 값을 대체하거나 Dto instance의 instance variable 또한 null로 초기화 되도록 수정함