### PR TITLE
CORS 설정 변경

### DIFF
--- a/src/main/java/kr/pe/aichief/config/WebConfig.java
+++ b/src/main/java/kr/pe/aichief/config/WebConfig.java
@@ -12,7 +12,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
-			.allowedOrigins("https://dev.ddnum7vb34gxw.amplifyapp.com", "http://localhost:3000")
+			.allowedOrigins("https://aichief.netlify.app")
 			.allowedMethods("*")
 			.allowCredentials(true);
 	}


### PR DESCRIPTION
# 📑 개요
프론트엔트 앱 배포 환경 변경에 따른 CORS 허용 출처 변경

# 📌 내용
- WebConfig에서 CORS 허용 출처를 https://aichief.netlify.app 으로 변경함